### PR TITLE
Merge staging fixes into legacy-bootstrap (v6.1.0)

### DIFF
--- a/includes/bip270-invoice.php
+++ b/includes/bip270-invoice.php
@@ -339,6 +339,7 @@ function BWWC__serve_receipt_download() {
         header('Cache-Control: no-cache, no-store, must-revalidate');
         header('Pragma: no-cache');
         header('Expires: 0');
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary BEEF data for file download
         echo $beef;
     } else {
         header('Content-Type: text/plain');
@@ -346,6 +347,7 @@ function BWWC__serve_receipt_download() {
         header('Cache-Control: no-cache, no-store, must-revalidate');
         header('Pragma: no-cache');
         header('Expires: 0');
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Raw transaction hex for file download
         echo $raw_tx;
     }
 

--- a/includes/bip270-payment-receiver.php
+++ b/includes/bip270-payment-receiver.php
@@ -186,6 +186,7 @@ function BWWC__receive_bip270_payment() {
     $ack_payload = array(
         'protocol' => 'bip270',
         'network' => 'bitcoin-sv',
+        /* translators: %d is the WooCommerce order number */
         'memo' => sprintf(__('Payment received for Order #%d', 'bsvanon-bitcoin-sv-payments'), $order_id),
         'merchantData' => array(
             'orderId' => $order_id,


### PR DESCRIPTION
## Changes
- Fixed 3 WordPress.org PluginCheck errors:
  - Added translators comment for sprintf placeholder in BIP270 payment acknowledgment
  - Added phpcs:ignore annotations for binary BEEF/transaction file downloads
- Fixed checkout icon thumbnail display (plugins_url() path resolution)
- Removed .gitignore from tracked files

## Testing
- PHP lint: all files clean
- WordPress.org PluginCheck: 3 ERRORS resolved
- Tag v6.1.0 updated to point to commit 39ee993

Ready for WordPress.org resubmission.