### PR TITLE
Release v6.1.1 – Plugin Check compliance hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SendBSV BSV Payments for WooCommerce
 
-**Version:** 6.1.0  
-**Status:** Production Ready - Major Security & Architecture Release  
+**Version:** 6.1.1  
+**Status:** Production Ready - WordPress.org Compliance Release  
 **Tested up to:** WordPress 6.9 / WooCommerce 10.4  
 **Requires:** WordPress 5.8+, WooCommerce 6.0+, PHP 7.4+
 

--- a/bitcoinway-woocommerce.php
+++ b/bitcoinway-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: SendBSV BSV Payments for WooCommerce
  * Plugin URI: https://github.com/BSVanon/bsv-woocommerce-gateway
  * Description: Accept Bitcoin SV (BSV) payments directly to your wallet for physical and digital products at your WooCommerce store. Self-custody, no third-party processor required.
- * Version: 6.1.0
+ * Version: 6.1.1
  * Author: BSVanon
  * Author URI: https://sendbsv.com
  * License: GPL-2.0-or-later

--- a/bwwc-include-all.php
+++ b/bwwc-include-all.php
@@ -11,7 +11,7 @@ https://github.com/mboyd1/bsvanon-bitcoin-sv-payments
 // ---------------------------------------------------------------------------
 // Global definitions
 if ( ! defined( 'BWWC_PLUGIN_NAME' ) ) {
-	define( 'BWWC_VERSION', '6.1.0' );
+	define( 'BWWC_VERSION', '6.1.1' );
 
 	// -----------------------------------------------
 	define( 'BWWC_EDITION', 'BSV' );

--- a/includes/gateway-validation.php
+++ b/includes/gateway-validation.php
@@ -89,11 +89,7 @@ function BWWC__is_gateway_valid_for_use( &$ret_reason_message = null ) {
 			if ( $max_age_hours > 0 && $age_in_hours > $max_age_hours ) {
 				$valid = false;
 				/* translators: 1: current age in hours, 2: maximum allowed hours */
-				$reason_message = sprintf(
-					__( 'Bitcoin SV payment option is temporarily unavailable. Exchange rate data is %1$s hours old (maximum allowed: %2$s hours). Please try again later or contact the store owner.', 'bsvanon-bitcoin-sv-payments' ),
-					number_format( $age_in_hours, 1 ),
-					$max_age_hours
-				);
+				$reason_message = sprintf( __( 'Bitcoin SV payment option is temporarily unavailable. Exchange rate data is %1$s hours old (maximum allowed: %2$s hours). Please try again later or contact the store owner.', 'bsvanon-bitcoin-sv-payments' ), number_format( $age_in_hours, 1 ), $max_age_hours );
 
 				if ( $ret_reason_message !== null ) {
 					$ret_reason_message = $reason_message;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: bitcoin sv, bsv, payment gateway, woocommerce, cryptocurrency
 Requires at least: 5.8
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 6.1.0
+Stable tag: 6.1.1
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 WC requires at least: 6.0
@@ -116,6 +116,14 @@ If you find this plugin useful, please consider supporting its development with 
 Your support helps maintain and improve this plugin for the entire BSV community!
 
 == Changelog ==
+
+= 6.1.1 - 2026-01-25 =
+**Critical WordPress.org compliance fix**
+
+* Fixed translators comment placement in gateway-validation.php to satisfy WordPress.org Plugin Check
+* Applied WordPress coding standards formatting (phpcbf)
+* Fixed Blocks checkout script registration paths
+* Fixed payment console CSS/JS asset loading
 
 = 6.1.0 - 2026-01-24 =
 **BRC-100 + Blocks polish release**


### PR DESCRIPTION
## Summary
- Fix WordPress.org PluginCheck translators comment error in includes/gateway-validation.php.
- Document compliance release + asset path fixes in readme files.
- Bump plugin/version metadata to 6.1.1.

## Testing
1. Payment console renders (QR/buttons/countdown) – PASS
2. WooCommerce Blocks checkout shows BSV option, scripts 200 – PASS
3. Admin settings icon selector works – PASS
4. PHPCS (WordPress.WP.I18n + WordPress.Security.EscapeOutput) – 0 errors
5. PHP lint on key files – PASS